### PR TITLE
feat: display transaction categorization + chart search filters

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from kaching_sdk import FoundryClient
 from foundry_sdk_runtime.auth import UserTokenAuth
 from flask import Flask, render_template, jsonify
 import pandas as pd
+from kaching_sdk.ontology.objects import Transaction
 
 app = Flask(__name__)
 
@@ -25,41 +26,94 @@ def dashboard():
 @app.route('/api/transactions')
 def get_transactions():
     TransactionObject = client.ontology.objects.Transaction
-    transactions = TransactionObject.iterate()
+    # Store all transactions in a list first
+    transaction_list = list(TransactionObject.iterate())
 
     data = []
-    for transaction in transactions:
+    for transaction in transaction_list:
         data.append({
             'date': transaction.date_,
             'amount': float(transaction.amount),
-            'description': transaction.description
+            'description': transaction.description,
+            'transaction_number': transaction.transaction_number
         })
 
     df = pd.DataFrame(data)
     df['date'] = pd.to_datetime(df['date'])
     df = df.sort_values('date')
 
+    # print(transaction_list)
+
+    # print(transaction_list)
+
+    # Get categories for transactions
+    try:
+        print("Creating transaction set...")
+        categories = client.ontology.queries.transaction_categorization(
+            transactions=TransactionObject
+        )
+        print(f"Categories received successfully.")
+
+        # Add categories to dataframe
+        df['category'] = 'Uncategorized'  # Default value
+
+        # Parse the JSON string into a dictionary if it's a string
+        if isinstance(categories, str):
+            import json
+            categories = json.loads(categories)
+
+        if isinstance(categories, dict):
+            # Create a mapping of transaction numbers to their categories
+            transaction_to_category = {}
+            category_totals = {}
+
+            for category, data in categories.items():
+                category_totals[category] = data['total']
+                for transaction in data['transactions']:
+                    transaction_to_category[transaction['transaction_number']] = category
+
+            # Add categories to dataframe by mapping transaction numbers
+            df['category'] = df.apply(
+                lambda row: transaction_to_category.get(
+                    row['transaction_number'], 'Uncategorized'),
+                axis=1
+            )
+
+            # Update category summary to use the new totals
+            category_summary = category_totals
+        else:
+            print(f"Unexpected categories format: {type(categories)}")
+
+    except Exception as e:
+        print(f"Error getting categories: {e}")
+        print(f"Error type: {type(e)}")
+        print(f"Error details: {str(e)}")
+        import traceback
+        print(f"Full traceback: {traceback.format_exc()}")
+        df['category'] = 'Uncategorized'
+
     # Separate credits and debits
     credits_df = df[df['amount'] < 0]
     debits_df = df[df['amount'] >= 0]
 
-    # Calculate daily counts for credits and debits
-    daily_credits = credits_df.groupby('date').size()
-    daily_debits = debits_df.groupby('date').size()
-    all_dates = df['date'].unique()
+    # Get category summaries for debits (spending)
+    category_summary = debits_df.groupby(
+        'category')['amount'].sum().apply(float).to_dict()
 
     return jsonify({
         'total_transactions': int(len(df)),
         'total_credits': float(credits_df['amount'].sum()),
         'total_debits': float(debits_df['amount'].sum()),
-        'daily_dates': [d.strftime('%Y-%m-%d') for d in all_dates],
-        'daily_credits': [int(daily_credits.get(d, 0)) for d in all_dates],
-        'daily_debits': [int(daily_debits.get(d, 0)) for d in all_dates],
+        'daily_dates': [d.strftime('%Y-%m-%d') for d in df['date'].unique()],
+        'daily_credits': [int(credits_df[credits_df['date'] == d].shape[0]) for d in df['date'].unique()],
+        'daily_debits': [int(debits_df[debits_df['date'] == d].shape[0]) for d in df['date'].unique()],
         'credit_amounts': [float(x) for x in credits_df['amount'].tolist()],
         'debit_amounts': [float(x) for x in debits_df['amount'].tolist()],
         'amounts': [float(x) for x in df['amount'].tolist()],
         'dates': df['date'].dt.strftime('%Y-%m-%d').tolist(),
-        'descriptions': df['description'].tolist()
+        'descriptions': df['description'].tolist(),
+        'categories': df['category'].tolist(),
+        'category_summary': category_summary
     })
 
 if __name__ == '__main__':

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,216 +1,367 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kaching</title>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        
-        .dashboard-container {
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-        
-        .header {
-            text-align: left;
-            margin-bottom: 30px;
-        }
-        
-        .stats-container {
-            display: flex;
-            justify-content: space-around;
-            margin-bottom: 30px;
-        }
-        
-        .stat-box {
-            background-color: white;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            text-align: center;
-            width: 200px;
-        }
-        
-        .chart-container {
-            background-color: white;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            margin-bottom: 20px;
-        }
-        
-        .refresh-button {
-            display: block;
-            margin: 20px auto;
-            padding: 10px 20px;
-            background-color: #007bff;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        
-        .refresh-button:hover {
-            background-color: #0056b3;
-        }
-        
-        .stat-box.credit {
-            border-left: 4px solid #28a745;
-        }
-        
-        .stat-box.debit {
-            border-left: 4px solid #dc3545;
-        }
-        
-        .credit-amount {
-            color: #28a745;
-            font-weight: bold;
-        }
-        
-        .debit-amount {
-            color: #dc3545;
-            font-weight: bold;
-        }
+      body {
+        font-family: 'Roboto', sans-serif;
+        background-color: #f8f9fa;
+        margin: 0;
+        padding: 20px;
+      }
+
+      .dashboard-container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
+      .header {
+        background-color: #fff;
+        padding: 20px;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        margin-bottom: 30px;
+      }
+
+      .stats-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 20px;
+        margin-bottom: 30px;
+      }
+
+      .stat-box {
+        background-color: white;
+        padding: 25px;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        transition: transform 0.2s;
+      }
+
+      .stat-box:hover {
+        transform: translateY(-5px);
+      }
+
+      .chart-container {
+        background-color: white;
+        padding: 25px;
+        border-radius: 10px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        margin-bottom: 20px;
+      }
+
+      .refresh-button {
+        display: inline-block;
+        padding: 12px 24px;
+        background-color: #0d6efd;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-weight: 500;
+        transition: background-color 0.2s;
+      }
+
+      .refresh-button:hover {
+        background-color: #0b5ed7;
+      }
+
+      .stat-box.credit { border-left: 4px solid #198754; }
+      .stat-box.debit { border-left: 4px solid #dc3545; }
+
+      .credit-amount { color: #198754; font-weight: 500; }
+      .debit-amount { color: #dc3545; font-weight: 500; }
+
+      h1 {
+        font-weight: 700;
+        color: #212529;
+        margin: 0;
+      }
+
+      h2 { font-size: 1.75rem; font-weight: 500; }
+      h3 { font-size: 1rem; color: #6c757d; margin-bottom: 10px; }
+
+      .filter-container {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .form-label {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: #6c757d;
+      }
+
+      .collapse {
+        transition: all 0.2s ease;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
     <div class="dashboard-container">
-        <div class="header">
-            <h1>kaching</h1>
+      <div class="header">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+          <h1>kaching</h1>
+          <div class="filter-container">
+            <button class="btn btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#filterSection">
+              <i class="fas fa-filter"></i> Filters
+            </button>
+          </div>
         </div>
         
-        <div class="stats-container">
-			<div class="stat-box">
-				<h3>Total Transactions</h3>
-				<h2 id="total-transactions">Loading...</h2>
-			</div>
-			<div class="stat-box credit">
-				<h3>Total Credits</h3>
-				<h2 id="total-credits">Loading...</h2>
-			</div>
-			<div class="stat-box debit">
-				<h3>Total Debits</h3>
-				<h2 id="total-debits">Loading...</h2>
-			</div>
-		</div>
-        
-        <div class="chart-container">
-            <div id="daily-transactions"></div>
+        <div class="collapse mb-3" id="filterSection">
+          <div class="card card-body">
+            <div class="row g-3">
+              <div class="col-md-3">
+                <label class="form-label">Date Range</label>
+                <input type="date" class="form-control" id="startDate">
+                <input type="date" class="form-control mt-2" id="endDate">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Amount Range</label>
+                <input type="number" class="form-control" id="minAmount" placeholder="Min">
+                <input type="number" class="form-control mt-2" id="maxAmount" placeholder="Max">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Categories</label>
+                <select class="form-select" id="categoryFilter" multiple>
+                  <!-- Will be populated dynamically -->
+                </select>
+              </div>
+              <div class="col-md-3">
+                <label class="form-label">Transaction Type</label>
+                <select class="form-select" id="typeFilter">
+                  <option value="all">All</option>
+                  <option value="credit">Credits</option>
+                  <option value="debit">Debits</option>
+                </select>
+              </div>
+            </div>
+            <div class="text-end mt-3">
+              <button class="btn btn-secondary me-2" onclick="resetFilters()">Reset</button>
+              <button class="btn btn-primary" onclick="applyFilters()">Apply</button>
+            </div>
+          </div>
         </div>
-        
-        <div class="chart-container">
-            <div id="amount-distribution"></div>
+      </div>
+
+      <div class="stats-container">
+        <div class="stat-box">
+          <h3>Total Transactions</h3>
+          <h2 id="total-transactions">Loading...</h2>
         </div>
-        
-        <div class="chart-container">
-            <div id="transaction-timeline"></div>
+        <div class="stat-box credit">
+          <h3>Total Credits</h3>
+          <h2 id="total-credits">Loading...</h2>
         </div>
-        
-        <button class="refresh-button" onclick="refreshData()">Refresh Data</button>
+        <div class="stat-box debit">
+          <h3>Total Debits</h3>
+          <h2 id="total-debits">Loading...</h2>
+        </div>
+      </div>
+
+      <div class="chart-container">
+        <div id="daily-transactions"></div>
+      </div>
+
+      <div class="chart-container">
+        <div id="amount-distribution"></div>
+      </div>
+
+      <div class="chart-container">
+        <div id="transaction-timeline"></div>
+      </div>
+
+      <div class="chart-container">
+        <div id="category-summary"></div>
+      </div>
+
+      <button class="refresh-button" onclick="refreshData()">
+        Refresh Data
+      </button>
     </div>
 
     <script>
-        function updateDashboard(data) {
-            // Update statistics
-            document.getElementById('total-transactions').textContent = data.total_transactions;
-            document.getElementById('total-credits').textContent = `$${Math.abs(data.total_credits).toLocaleString()}`;
-            document.getElementById('total-debits').textContent = `$${data.total_debits.toLocaleString()}`;
-            
-            // Daily Transactions Chart
-            Plotly.newPlot('daily-transactions', [
-                {
-                    x: data.daily_dates,
-                    y: data.daily_credits,
-                    type: 'bar',
-                    name: 'Credits',
-                    marker: { color: '#28a745' }
-                },
-                {
-                    x: data.daily_dates,
-                    y: data.daily_debits,
-                    type: 'bar',
-                    name: 'Debits',
-                    marker: { color: '#dc3545' }
-                }
-            ], {
-                title: 'Daily Transaction Count',
-                xaxis: { 
-                    title: 'Date',
-                    type: 'date',
-                    tickformat: '%Y-%m-%d',
-                    tickangle: 45
-                },
-                yaxis: { title: 'Number of Transactions' },
-                barmode: 'group'
-            });
-            
-            // Amount Distribution
-            Plotly.newPlot('amount-distribution', [
-                {
-                    x: data.credit_amounts,
-                    type: 'histogram',
-                    name: 'Credits',
-                    marker: { color: '#28a745' }
-                },
-                {
-                    x: data.debit_amounts,
-                    type: 'histogram',
-                    name: 'Debits',
-                    marker: { color: '#dc3545' }
-                }
-            ], {
-                title: 'Transaction Amount Distribution',
-                xaxis: { title: 'Amount ($)' },
-                yaxis: { title: 'Frequency' },
-                barmode: 'overlay',
-                opacity: 0.7
-            });
-            
-            // Transaction Timeline
-            Plotly.newPlot('transaction-timeline', [{
-                x: data.dates,
-                y: data.amounts,
-                mode: 'markers',
-                type: 'scatter',
-                text: data.descriptions,
-                marker: {
-                    color: data.amounts.map(amount => amount < 0 ? '#28a745' : '#dc3545'),
-                    size: 8
-                },
-                hovertemplate: 
-                    '<b>%{text}</b><br>' +
-                    '<b>Amount:</b> $%{y:.2f}<br>' +
-                    '<b>Date:</b> %{x}<br>'
-            }], {
-                title: 'Transaction Timeline',
-                xaxis: { 
-                    title: 'Date',
-                    type: 'date',
-                    tickformat: '%Y-%m-%d',
-                    tickangle: 45
-                },
-                yaxis: { title: 'Amount ($)' },
-                showlegend: false
-            });
-        }
+      function updateDashboard(data) {
+        // Update statistics
+        document.getElementById("total-transactions").textContent =
+          data.total_transactions;
+        document.getElementById("total-credits").textContent = `$${Math.abs(
+          data.total_credits
+        ).toLocaleString()}`;
+        document.getElementById(
+          "total-debits"
+        ).textContent = `$${data.total_debits.toLocaleString()}`;
 
-        function refreshData() {
-            fetch('/api/transactions')
-                .then(response => response.json())
-                .then(data => updateDashboard(data))
-                .catch(error => console.error('Error:', error));
-        }
+        const plotlyConfig = {
+          template: 'plotly_white',
+          margin: { t: 30, b: 30, l: 40, r: 20 },
+          font: { family: 'Roboto' }
+        };
 
-        // Initial load
-        refreshData();
+        // Update all chart layouts to use the config
+        Plotly.newPlot("daily-transactions", [
+          {
+            x: data.daily_dates,
+            y: data.daily_credits,
+            type: "bar",
+            name: "Credits",
+            marker: { color: "#198754", opacity: 0.8 },
+          },
+          {
+            x: data.daily_dates,
+            y: data.daily_debits,
+            type: "bar",
+            name: "Debits",
+            marker: { color: "#dc3545", opacity: 0.8 },
+          },
+        ],
+        {
+          ...plotlyConfig,
+          title: "Daily Transaction Count",
+          xaxis: {
+            title: "Date",
+            type: "date",
+            tickformat: "%Y-%m-%d",
+            tickangle: 45,
+          },
+          yaxis: { title: "Number of Transactions" },
+          barmode: "group",
+        });
+
+        // Amount Distribution
+        Plotly.newPlot(
+          "amount-distribution",
+          [
+            {
+              x: data.credit_amounts,
+              type: "histogram",
+              name: "Credits",
+              marker: { color: "#28a745" },
+            },
+            {
+              x: data.debit_amounts,
+              type: "histogram",
+              name: "Debits",
+              marker: { color: "#dc3545" },
+            },
+          ],
+          {
+            title: "Transaction Amount Distribution",
+            xaxis: { title: "Amount ($)" },
+            yaxis: { title: "Frequency" },
+            barmode: "overlay",
+            opacity: 0.7,
+          }
+        );
+
+        // Category Summary Pie Chart
+        const categoryData = {
+          values: [],
+          labels: [],
+          type: "pie",
+          hole: 0.4,
+          textposition: 'inside',
+          textinfo: 'percent+label',
+          marker: {
+            colors: [
+              "#4CAF50",
+              "#2196F3",
+              "#FF9800",
+              "#F44336",
+              "#9C27B0",
+              "#00BCD4",
+              "#FFEB3B",
+              "#795548",
+            ],
+          },
+        };
+
+        let uncategorizedTotal = 0;
+        // Only include positive totals in the pie chart, excluding Uncategorized
+        Object.entries(data.category_summary).forEach(([category, total]) => {
+          if (total > 0) {
+            if (category === 'Uncategorized') {
+              uncategorizedTotal = total;
+            } else {
+              categoryData.labels.push(category);
+              categoryData.values.push(total);
+            }
+          }
+        });
+
+        const layout = {
+          title: "Spending by Category",
+          showlegend: false,
+          hoverinfo: 'label+percent+value',
+          annotations: [{
+            text: `Uncategorized Spending: $${uncategorizedTotal.toLocaleString()}`,
+            showarrow: false,
+            x: 0.5,
+            y: -0.2,
+            font: {
+              size: 14
+            }
+          }]
+        };
+
+        Plotly.newPlot("category-summary", [categoryData], layout);
+
+        // Update Transaction Timeline to include categories
+        Plotly.newPlot(
+          "transaction-timeline",
+          [
+            {
+              x: data.dates,
+              y: data.amounts,
+              mode: "markers",
+              type: "scatter",
+              text: data.descriptions,
+              customdata: data.categories, // Add categories as custom data
+              marker: {
+                color: data.amounts.map((amount) =>
+                  amount < 0 ? "#28a745" : "#dc3545"
+                ),
+                size: 8,
+              },
+              hovertemplate:
+                "<b>%{text}</b><br>" +
+                "<b>Amount:</b> $%{y:.2f}<br>" +
+                "<b>Date:</b> %{x}<br>" +
+                "<b>Category:</b> %{customdata}<br>",
+            },
+          ],
+          {
+            title: "Transaction Timeline",
+            xaxis: {
+              title: "Date",
+              type: "date",
+              tickformat: "%Y-%m-%d",
+              tickangle: 45,
+            },
+            yaxis: { title: "Amount ($)" },
+            showlegend: false,
+          }
+        );
+      }
+
+      function refreshData() {
+        fetch("/api/transactions")
+          .then((response) => response.json())
+          .then((data) => updateDashboard(data))
+          .catch((error) => console.error("Error:", error));
+      }
+
+      // Initial load
+      refreshData();
     </script>
-</body>
+  </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,10 +6,9 @@
     <title>kaching</title>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <style>
       body {
         font-family: 'Roboto', sans-serif;
@@ -190,6 +189,144 @@
     </div>
 
     <script>
+      let originalData = null;
+      
+      function applyFilters() {
+        if (!originalData) return;
+        
+        const startDate = document.getElementById('startDate').value;
+        const endDate = document.getElementById('endDate').value;
+        const minAmount = document.getElementById('minAmount').value;
+        const maxAmount = document.getElementById('maxAmount').value;
+        const categories = Array.from(document.getElementById('categoryFilter').selectedOptions).map(opt => opt.value);
+        const type = document.getElementById('typeFilter').value;
+        
+        let filteredData = {...originalData};
+        
+        // Apply date filters
+        if (startDate || endDate) {
+          const filteredIndices = originalData.dates.map((date, i) => {
+            const txDate = new Date(date);
+            if (startDate && txDate < new Date(startDate)) return false;
+            if (endDate && txDate > new Date(endDate)) return false;
+            return true;
+          });
+          filterDataByIndices(filteredData, filteredIndices);
+        }
+        
+        // Apply amount filters
+        if (minAmount || maxAmount) {
+          const filteredIndices = originalData.amounts.map((amount, i) => {
+            const absAmount = Math.abs(amount);
+            if (minAmount && absAmount < parseFloat(minAmount)) return false;
+            if (maxAmount && absAmount > parseFloat(maxAmount)) return false;
+            return true;
+          });
+          filterDataByIndices(filteredData, filteredIndices);
+        }
+        
+        // Apply category filters
+        if (categories.length > 0) {
+          const filteredIndices = originalData.categories.map((category, i) => 
+            categories.includes(category)
+          );
+          filterDataByIndices(filteredData, filteredIndices);
+        }
+        
+        // Apply transaction type filter
+        if (type !== 'all') {
+          const filteredIndices = originalData.amounts.map((amount, i) => 
+            type === 'credit' ? amount < 0 : amount >= 0
+          );
+          filterDataByIndices(filteredData, filteredIndices);
+        }
+
+        // Recalculate totals
+        filteredData.total_transactions = filteredData.amounts.length;
+        filteredData.total_credits = filteredData.amounts.filter(a => a < 0).reduce((a, b) => a + b, 0);
+        filteredData.total_debits = filteredData.amounts.filter(a => a >= 0).reduce((a, b) => a + b, 0);
+        
+        // Recalculate daily summaries
+        const dailyData = getDailySummary(filteredData.dates, filteredData.amounts);
+        filteredData.daily_dates = dailyData.dates;
+        filteredData.daily_credits = dailyData.credits;
+        filteredData.daily_debits = dailyData.debits;
+        
+        // Update category summary
+        filteredData.category_summary = {};
+        filteredData.categories.forEach((category, i) => {
+          if (filteredData.amounts[i] >= 0) {  // only include debits in category summary
+            if (!filteredData.category_summary[category]) {
+              filteredData.category_summary[category] = 0;
+            }
+            filteredData.category_summary[category] += filteredData.amounts[i];
+          }
+        });
+        
+        updateDashboard(filteredData);
+      }
+      
+      function filterDataByIndices(data, indices) {
+        Object.keys(data).forEach(key => {
+          if (Array.isArray(data[key])) {
+            data[key] = data[key].filter((_, i) => indices[i]);
+          }
+        });
+      }
+      
+      function getDailySummary(dates, amounts) {
+        const dailyMap = new Map();
+        dates.forEach((date, i) => {
+          if (!dailyMap.has(date)) {
+            dailyMap.set(date, { credits: 0, debits: 0 });
+          }
+          if (amounts[i] < 0) {
+            dailyMap.get(date).credits++;
+          } else {
+            dailyMap.get(date).debits++;
+          }
+        });
+        
+        const sortedDates = [...new Set(dates)].sort();
+        return {
+          dates: sortedDates,
+          credits: sortedDates.map(d => dailyMap.get(d).credits),
+          debits: sortedDates.map(d => dailyMap.get(d).debits)
+        };
+      }
+      
+      function resetFilters() {
+        document.getElementById('startDate').value = '';
+        document.getElementById('endDate').value = '';
+        document.getElementById('minAmount').value = '';
+        document.getElementById('maxAmount').value = '';
+        document.getElementById('categoryFilter').selectedIndex = -1;
+        document.getElementById('typeFilter').value = 'all';
+        
+        if (originalData) {
+          updateDashboard(originalData);
+        }
+      }
+
+      // Modify the existing refreshData function
+      function refreshData() {
+        fetch("/api/transactions")
+          .then((response) => response.json())
+          .then((data) => {
+            originalData = data;  // Store the original data
+            
+            // Populate category filter options
+            const categorySelect = document.getElementById('categoryFilter');
+            const uniqueCategories = [...new Set(data.categories)];
+            categorySelect.innerHTML = uniqueCategories
+              .map(cat => `<option value="${cat}">${cat}</option>`)
+              .join('');
+            
+            updateDashboard(data);
+          })
+          .catch((error) => console.error("Error:", error));
+      }
+
       function updateDashboard(data) {
         // Update statistics
         document.getElementById("total-transactions").textContent =
@@ -351,13 +488,6 @@
             showlegend: false,
           }
         );
-      }
-
-      function refreshData() {
-        fetch("/api/transactions")
-          .then((response) => response.json())
-          .then((data) => updateDashboard(data))
-          .catch((error) => console.error("Error:", error));
       }
 
       // Initial load


### PR DESCRIPTION
- added LLM generated categorization's of credit card transactions and plotted using plotly
- add a filter feature to narrow chart results

todo:
- improve LLM model to generate better categorization since currently ~95% of transactions are not being categorized due to inadequate descriptions in the credit card statements
